### PR TITLE
Dungeon Portals and InventorySnapshot

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.caching                  =   true
 ### Build Info ###
 build_status                        =   alpha
 build_number                        =   1
-project_version                     =   0.6.1
+project_version                     =   0.7.0
 author                              =   QuickScythe
 
 ### Argument Info ###

--- a/src/main/java/com/dragon/lastlife/Initializer.java
+++ b/src/main/java/com/dragon/lastlife/Initializer.java
@@ -5,6 +5,7 @@ import com.dragon.lastlife.commands.executor.BoogeyCommand;
 import com.dragon.lastlife.commands.executor.ConfigCommand;
 import com.dragon.lastlife.commands.executor.DonationsCommand;
 import com.dragon.lastlife.commands.executor.LifeCommand;
+import com.dragon.lastlife.listeners.EntityTeleportEventListener;
 import com.dragon.lastlife.listeners.FoxPersistenceListener;
 import com.dragon.lastlife.listeners.LootListener;
 import com.dragon.lastlife.listeners.PlayerListener;
@@ -27,9 +28,10 @@ public final class Initializer extends JavaPlugin {
     public PlayerListener PLAYER_LISTENER = new PlayerListener();
     public LootListener LOOT_LISTENER = new LootListener();
     public FoxPersistenceListener FOX_PERSISTENCE_LISTENER = new FoxPersistenceListener();
+    public EntityTeleportEventListener ENTITY_TELEPORT_LISTENER = new EntityTeleportEventListener();
 
     private final List<Listener> listeners = Arrays.asList(
-            PLAYER_LISTENER, LOOT_LISTENER, FOX_PERSISTENCE_LISTENER
+            PLAYER_LISTENER, LOOT_LISTENER, FOX_PERSISTENCE_LISTENER, ENTITY_TELEPORT_LISTENER
     );
 
     public void quipt() {

--- a/src/main/java/com/dragon/lastlife/listeners/EntityTeleportEventListener.java
+++ b/src/main/java/com/dragon/lastlife/listeners/EntityTeleportEventListener.java
@@ -1,0 +1,49 @@
+package com.dragon.lastlife.listeners;
+
+import com.destroystokyo.paper.event.player.PlayerTeleportEndGatewayEvent;
+import com.dragon.lastlife.players.InventorySnapshot;
+import com.dragon.lastlife.utils.Utils;
+import com.dragon.lastlife.world.DungeonManager;
+import org.bukkit.Location;
+import org.bukkit.PortalType;
+import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityPortalEnterEvent;
+import org.bukkit.event.player.PlayerPortalEvent;
+
+public class EntityTeleportEventListener implements Listener {
+    @EventHandler
+    // This gets spammed for nether portals, but allows for EndGateway detection without an exit_portal:[X, Y, Z] attribute
+    public void onEntityPortalEnter(EntityPortalEnterEvent event) {
+        Utils.initializer().getComponentLogger().error("onEntityPortalEnter");
+    }
+
+    @EventHandler
+    // Nether / End Portal blocks
+    public void onPlayerPortal(PlayerPortalEvent event) {
+        Utils.initializer().getComponentLogger().error("onPlayerPortal");
+    }
+
+    @EventHandler
+    // End Gateway blocks. Only gets triggered for EndGateway with an exit_portal:[X, Y, Z] attribute
+    public void onPlayerTeleportEndGateway(PlayerTeleportEndGatewayEvent event) {
+        Utils.initializer().getComponentLogger().error("onPlayerTeleportEndGateway");
+
+        DungeonManager manager = Utils.configs().DUNGEON_MANAGER;
+
+        String dimension = ((CraftWorld) event.getGateway().getWorld()).getHandle().dimension().location().toString();
+        if (dimension.equals("minecraft:overworld")) {
+            Location to = manager.getDungeonEntranceLocation();
+            if (to == null) {
+                event.setCancelled(true);
+                Utils.initializer().getComponentLogger().error("Failed to TP player to Dungeon");
+            } else {
+                event.setTo(to);
+                InventorySnapshot.takePlayerInventorySnapshot(event.getPlayer());
+            }
+        } else if (dimension.equals("lastlife:dungeon_dim")) {
+            event.setTo(manager.getDungeonExitLocation());
+        }
+    }
+}

--- a/src/main/java/com/dragon/lastlife/players/InventorySnapshot.java
+++ b/src/main/java/com/dragon/lastlife/players/InventorySnapshot.java
@@ -1,0 +1,270 @@
+package com.dragon.lastlife.players;
+
+import com.dragon.lastlife.utils.Utils;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.visitors.CollectToTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.ProblemReporter;
+import net.minecraft.world.ItemStackWithSlot;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
+import net.minecraft.world.level.storage.TagValueInput;
+import net.minecraft.world.level.storage.TagValueOutput;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import org.bukkit.NamespacedKey;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static net.minecraft.world.entity.player.Inventory.EQUIPMENT_SLOT_MAPPING;
+import static net.minecraft.world.entity.player.Inventory.INVENTORY_SIZE;
+import static org.bukkit.persistence.PersistentDataType.STRING;
+
+public class InventorySnapshot {
+    static public NamespacedKey INVENTORY_SNAPSHOT = new NamespacedKey(Utils.initializer(), "inventory_snapshot");
+
+    static private final List<Item> BUCKETS = List.of(
+            Items.BUCKET, Items.WATER_BUCKET, Items.LAVA_BUCKET, Items.POWDER_SNOW_BUCKET, Items.MILK_BUCKET,
+            Items.AXOLOTL_BUCKET, Items.COD_BUCKET, Items.PUFFERFISH_BUCKET, Items.SALMON_BUCKET, Items.TADPOLE_BUCKET, Items.TROPICAL_FISH_BUCKET
+    );
+    static private final List<Item> BOTTLES = List.of(
+            Items.GLASS_BOTTLE, Items.POTION, Items.HONEY_BOTTLE
+    );
+    static private final List<Item> BOWLS = List.of(
+            Items.BOWL, Items.MUSHROOM_STEW, Items.SUSPICIOUS_STEW, Items.RABBIT_STEW, Items.BEETROOT_SOUP
+    );
+    static private final List<List<Item>> TRANSFORMATIVE_ITEM_TYPES = List.of(
+            BUCKETS, BOTTLES, BOWLS
+    );
+
+    static private final List<Item> TRANSFORMATIVE_ITEMS = TRANSFORMATIVE_ITEM_TYPES.stream().flatMap(List::stream).toList();
+
+    public static void takePlayerInventorySnapshot(Player player) {
+        ServerPlayer serverPlayer = ((CraftPlayer) player).getHandle();
+        try (ProblemReporter.ScopedCollector scopedCollector = new ProblemReporter.ScopedCollector(serverPlayer.problemPath(), Utils.initializer().getSLF4JLogger())) {
+            TagValueOutput nbt = TagValueOutput.createWithContext(scopedCollector, serverPlayer.registryAccess());
+            ValueOutput.TypedOutputList<ItemStackWithSlot> snapshot = nbt.list("InventorySnapshot", ItemStackWithSlot.CODEC);
+
+            List<ItemStack> items = serverPlayer.getInventory().getContents();
+
+            for (int i = 0; i < items.size(); ++i) {
+                ItemStack itemStack = items.get(i);
+                if (!itemStack.isEmpty()) {
+                    snapshot.add(new ItemStackWithSlot(i, itemStack));
+                }
+            }
+
+            CompoundTag result = nbt.buildResult();
+            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            DataOutputStream output = new DataOutputStream(stream);
+            try {
+                NbtIo.write(result, output);
+                player.getPersistentDataContainer().set(INVENTORY_SNAPSHOT, STRING, stream.toString());
+            } catch (IOException e) {
+                Utils.initializer().getComponentLogger().error("Failed to write CompundTag: ", e);
+            }
+        }
+    }
+
+    private static SimpleContainer getInventorySnapshot(ServerPlayer player) {
+        CraftPlayer craftPlayer = player.getBukkitEntity();
+        String data = craftPlayer.getPersistentDataContainer().get(INVENTORY_SNAPSHOT, STRING);
+        if (data == null) {
+            return null;
+        }
+
+        try (ProblemReporter.ScopedCollector scopedCollector = new ProblemReporter.ScopedCollector(player.problemPath(), Utils.initializer().getSLF4JLogger())) {
+            DataInputStream input = new DataInputStream(new ByteArrayInputStream(data.getBytes()));
+            CollectToTag tag = new CollectToTag();
+            NbtIo.parse(input, tag, NbtAccounter.create(104857600L));
+            SimpleContainer container = new SimpleContainer(EQUIPMENT_SLOT_MAPPING.size() + INVENTORY_SIZE);
+
+            ValueInput tagInput = TagValueInput.createGlobal(scopedCollector, tag.getResult().asCompound().get());
+
+            for (ItemStackWithSlot itemStackWithSlot : tagInput.list("InventorySnapshot", ItemStackWithSlot.CODEC).get()) {
+                if (itemStackWithSlot.isValidInContainer(container.items.size())) {
+                    container.setItem(itemStackWithSlot.slot(), itemStackWithSlot.stack());
+                }
+            }
+
+            return container;
+        } catch (IOException e) {
+            Utils.initializer().getComponentLogger().error("Failed to parse CompundTag: ", e);
+            return null;
+        }
+    }
+
+    private static HashMap<Item, Integer> getTransformativeItemsCountMap(List<ItemStack> items) {
+        HashMap<Item, Integer> transformativeItems = new HashMap<>();
+
+        for (ItemStack stack : items) {
+            Item item = stack.getItem();
+
+            if (TRANSFORMATIVE_ITEMS.contains(item)) {
+                int count = stack.getCount();
+
+                transformativeItems.compute(item, (ii, value) -> value == null ? count : count + value);
+            }
+        }
+
+        return transformativeItems;
+    }
+
+    private static int findMatchingItem(ItemStack item, List<ItemStack> snapshotItems, HashMap<Item, Integer> snapshotTransformativeItems) {
+        for (int i = 0; i < snapshotItems.size(); i++) {
+            ItemStack snapshotItem = snapshotItems.get(i);
+            // Not the same item, keep searching
+            if (snapshotItem.isEmpty() || !item.is(snapshotItem.getItem())) {
+                continue;
+            }
+
+            DataComponentMap itemComponents = item.getComponents();
+            DataComponentMap snapshotComponents = snapshotItem.getComponents();
+
+            // If same item but less durability -> keep. If item has mending, disregard durability check
+            if (itemComponents.has(DataComponents.DAMAGE) || snapshotComponents.has(DataComponents.DAMAGE)) {
+                int damage = itemComponents.getOrDefault(DataComponents.DAMAGE, 0);
+                int snapshotDamage = snapshotComponents.getOrDefault(DataComponents.DAMAGE, 0);
+                ItemEnchantments enchants = snapshotComponents.get(DataComponents.ENCHANTMENTS);
+                DataComponentMap itemComponentsCopy = DataComponentMap.builder().addAll(itemComponents).set(DataComponents.DAMAGE, null).build();
+                DataComponentMap snapshotComponentsCopy = DataComponentMap.builder().addAll(snapshotComponents).set(DataComponents.DAMAGE, null).build();
+
+                // The items have other components differences other than durability -> Not the same item
+                if (!itemComponentsCopy.equals(snapshotComponentsCopy)) {
+                    continue;
+                }
+
+                // Item has taken more (durability) damage, but that's the only difference. We should keep it.
+                if (damage >= snapshotDamage) {
+                    return i;
+                }
+                // Item has mending, we don't care about durability difference
+                if (enchants != null && enchants.keySet().stream().anyMatch(e -> e.is(Enchantments.MENDING))) {
+                    return i;
+                }
+            } else if (itemComponents.equals(snapshotComponents)) {
+                return i;
+            }
+        }
+
+        // Check if item is transformative
+        Optional<List<Item>> transformativeCategory = TRANSFORMATIVE_ITEM_TYPES.stream().filter(list -> list.contains(item.getItem())).findFirst();
+
+        if (transformativeCategory.isPresent()) {
+            // find transformed item in snapshot. We ignore components for transformed items
+            for (int i = 0; i < snapshotItems.size(); i++) {
+                ItemStack snapshotItem = snapshotItems.get(i);
+                Item itemType = snapshotItem.getItem();
+                int available = snapshotTransformativeItems.getOrDefault(itemType, 0);
+
+                if (transformativeCategory.get().contains(itemType) && available > 0) {
+                    //noinspection DataFlowIssue
+                    snapshotTransformativeItems.compute(itemType, (key, count) -> count - 1);
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    public static void applyPlayerInventorySnapshot(ServerPlayer player, PlayerDeathEvent event) {
+        SimpleContainer snapshot = getInventorySnapshot(player);
+
+        if (snapshot == null) {
+            Utils.initializer().getComponentLogger().error("Failed to get InventorySnapshot - leaving player inventory untouched");
+            return;
+        }
+
+        Inventory inventory = player.getInventory();
+        List<ItemStack> items = inventory.getContents();
+        List<ItemStack> snapshotItems = snapshot.getContents();
+        @NotNull List<org.bukkit.inventory.ItemStack> drops = event.getDrops();
+        HashMap<Item, Integer> transformativeItems = getTransformativeItemsCountMap(items);
+        HashMap<Item, Integer> snapshotTransformativeItems = getTransformativeItemsCountMap(snapshotItems);
+
+        // Allocate each transformative item in the snapshot to un-transformed items in inventory.
+        // snapshotTransformativeItems will contain the remainder after all exact matches have been accounted for.
+        snapshotTransformativeItems.replaceAll((item, count) -> {
+            int newCount = transformativeItems.getOrDefault(item, 0);
+
+            if (newCount > count) {
+                return 0;
+            } else {
+                return count - newCount;
+            }
+        });
+
+        for (int i = 0; i < items.size(); i++) {
+            ItemStack item = items.get(i);
+            if (item.isEmpty()) {
+                continue;
+            }
+
+            int currentCount = item.getCount();
+
+            // In case player merged 2 item stacks, we will loop until we find all the quantities in the snapshot, or run out of matching items
+            while (true) {
+                int snapshotItemIndex = findMatchingItem(item, snapshotItems, snapshotTransformativeItems);
+
+                // Item not found in snapshot : dropping
+                if (snapshotItemIndex == -1) {
+                    int countFound = item.getCount() - currentCount;
+
+                    if (countFound == 0) {
+                        // Item was completely not found in snapshot - removing from inventory
+                        drops.add(item.asBukkitCopy());
+                        inventory.setItem(i, ItemStack.EMPTY);
+                    } else {
+                        // Item was partially found in snapshot - keeping that amount and dropping the excess
+                        org.bukkit.inventory.ItemStack drop = item.asBukkitCopy();
+
+                        item.setCount(countFound);
+                        drop.subtract(countFound);
+                        drops.add(drop);
+                    }
+                    break;
+                }
+
+                ItemStack snapshotItem = snapshotItems.get(snapshotItemIndex);
+
+                int countBefore = snapshotItem.getCount();
+                int countDifference = currentCount - countBefore;
+
+                // player has less quantity than in snapshot
+                if (countDifference < 0) {
+                    // In case the player split the stack, we keep track of how many where used
+                    snapshotItem.shrink(currentCount);
+                    break;
+                }
+
+                // SnapshotItem quantity has been fully "used", removing it from snapshot so it's not used by subsequent item searches
+                snapshotItems.set(snapshotItemIndex, ItemStack.EMPTY);
+
+                // Got exact count match, continue to next item
+                if (countDifference == 0) {
+                    break;
+                }
+
+                // If item count higher -> Count we found some, and keep looking
+                currentCount -= countBefore;
+            }
+        }
+    }
+}

--- a/src/main/java/com/dragon/lastlife/players/Participant.java
+++ b/src/main/java/com/dragon/lastlife/players/Participant.java
@@ -70,7 +70,6 @@ public class Participant extends ConfigObject {
         }
     }
 
-
     public OfflinePlayer player() {
         return Bukkit.getOfflinePlayer(UUID.fromString(id));
     }
@@ -86,7 +85,6 @@ public class Participant extends ConfigObject {
     }
 
     public class LifeManager {
-
         public void update() {
             if (lives <= 0) {
                 color(NamedTextColor.GRAY);

--- a/src/main/java/com/dragon/lastlife/world/DungeonManager.java
+++ b/src/main/java/com/dragon/lastlife/world/DungeonManager.java
@@ -1,41 +1,69 @@
 package com.dragon.lastlife.world;
 
 import com.dragon.lastlife.Initializer;
+import com.dragon.lastlife.utils.Utils;
+import com.google.common.collect.Lists;
 import com.quiptmc.core.data.registries.Registries;
 import com.quiptmc.core.data.registries.Registry;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.visitors.CollectToTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.ProblemReporter;
+import net.minecraft.world.ItemStackWithSlot;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.ChunkPos;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.World;
-import org.bukkit.WorldCreator;
+import net.minecraft.world.level.storage.TagValueInput;
+import net.minecraft.world.level.storage.TagValueOutput;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import org.bukkit.*;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
-import java.util.Optional;
+import java.io.*;
+import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static com.dragon.lastlife.world.Dungeon.DUNGEON_RESOURCE_KEY;
 import static net.kyori.adventure.text.Component.text;
+import static net.minecraft.world.entity.player.Inventory.*;
+import static org.bukkit.persistence.PersistentDataType.STRING;
 
 public class DungeonManager {
+
+    public World dungeon_world;
 
     Initializer initializer;
     Registry<Dungeon> registry = Registries.register("lastlife:dungeons", () -> null);
 
     public DungeonManager(Initializer initializer) {
         this.initializer = initializer;
+        dungeon_world = Bukkit.getWorld("world_lastlife_dungeon_dim");
     }
 
-    public static Location getDungeonEntranceLocation() {
-        World world = Bukkit.getWorld("world_lastlife_dungeon_dim");
-
-        if (world == null) {
+    public Location getDungeonEntranceLocation() {
+        if (dungeon_world == null) {
             return null;
         }
         // These coordinates are always the same, because of how the dungeon is generated in the custom dimension
-        Location tp_location = new Location(world, -96, 100, -32);
-        Collection<Entity> entities = world.getNearbyEntities(tp_location, 7, 1, 7);
+        Location tp_location = new Location(dungeon_world, -96, 100, -32);
+        Collection<Entity> entities = dungeon_world.getNearbyEntities(tp_location, 7, 1, 7);
         Optional<Entity> spawn_marker = entities.stream().filter(entity -> "lastlife:dungeon/spawn".equals(entity.getName())).findFirst();
 
         if (spawn_marker.isPresent()) {
@@ -44,9 +72,11 @@ public class DungeonManager {
         return tp_location;
     }
 
-    public static Location getDungeonExitLocation() {
-        // TODO: Will need to detect the spawn coordinates somehow
-        return new Location(Bukkit.getWorlds().getFirst(), 182, 74, 338);
+    public Location getDungeonExitLocation() {
+        World overworld = Bukkit.getWorlds().getFirst(); // TODO: Does this always work ?
+
+        // TODO: Do we want custom coordinates instead ?
+        return overworld.getSpawnLocation();
     }
 
     public void create(String name, ChunkPos pos, Consumer<Dungeon> callback) {


### PR DESCRIPTION
- New listener for TP events
- On EndGateway TP event (requires gateway block to have a destination) enter/exit the dungeon
- Take a snapshot of player inventory on Dungeon entrance
- If player death inside dungeon, restore inventory based on snapshot